### PR TITLE
Ignore draftfile.php

### DIFF
--- a/classes/clean_moodle_url.php
+++ b/classes/clean_moodle_url.php
@@ -161,6 +161,12 @@ class clean_moodle_url extends \moodle_url {
             self::log("Ignoring pluginfile urls");
             return $orig;
         }
+        
+        // Ignore any draft files.
+        if (substr($path, 0, 14) == '/draftfile.php') {
+            self::log("Ignoring draftfile urls");
+            return $orig;
+        }
 
         // Ignore non .php files.
         if (substr($path, -4) !== ".php") {


### PR DESCRIPTION
When uploading images there will be a draftfile created. At the moment the image cannot be display because the draftfile.php is not ignored. This update will ignore the draftfile.php so images will be displayed.