### PR TITLE
Ignore draftfile.php

### DIFF
--- a/classes/clean_moodle_url.php
+++ b/classes/clean_moodle_url.php
@@ -161,6 +161,12 @@ class clean_moodle_url extends \moodle_url {
             self::log("Ignoring pluginfile urls");
             return $orig;
         }
+        
+        // Ignore any draft files.
+        if (substr($path, 0, 14) == '/draftfile.php') {
+            self::log("Ignoring draftfile urls");
+            return $orig;
+        }
 
         // Ignore non .php files.
         if (substr($path, -4) !== ".php") {

--- a/classes/clean_moodle_url.php
+++ b/classes/clean_moodle_url.php
@@ -161,7 +161,7 @@ class clean_moodle_url extends \moodle_url {
             self::log("Ignoring pluginfile urls");
             return $orig;
         }
-        
+
         // Ignore any draft files.
         if (substr($path, 0, 14) == '/draftfile.php') {
             self::log("Ignoring draftfile urls");


### PR DESCRIPTION
Uploaded images via the HTML editor will be loaded from draftfile.php. This file should not be rewrited, so images can be displayed.