### PR TITLE
Keeps the trailing slash in URLs.

### DIFF
--- a/classes/local/cleaner/cleaner.php
+++ b/classes/local/cleaner/cleaner.php
@@ -328,7 +328,7 @@ class cleaner {
 
     private function create_cleaned_url() {
         // Add back moodle path.
-        $this->path = $this->moodlepath . '/' . trim($this->path, '/');
+        $this->path = $this->moodlepath . '/' . ltrim($this->path, '/');
 
         // URL was not rewritten.
         if ($this->path == $this->originalpath) {

--- a/tests/phpunit/clean_unclean/courseformat/singleactivity_test.php
+++ b/tests/phpunit/clean_unclean/courseformat/singleactivity_test.php
@@ -41,7 +41,7 @@ class local_cleanurls_simpleactivity_cleanunclean_test extends local_cleanurls_t
         $forum = $this->getDataGenerator()->create_module('forum', ['course' => $course->id, 'name' => 'The Single Forum']);
 
         $url = 'http://www.example.com/moodle/mod/forum/view.php?id=' . $forum->cmid;
-        $expected = 'http://www.example.com/moodle/course/SingleActivity';
+        $expected = 'http://www.example.com/moodle/course/SingleActivity/';
         static::assert_clean_unclean($url, $expected);
     }
 

--- a/tests/phpunit/cleaner/cleaner_test.php
+++ b/tests/phpunit/cleaner/cleaner_test.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for cleaner.
+ *
+ * @package     local_cleanurls
+ * @author      Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
+ * @copyright   2017 Catalyst IT Australia {@link http://www.catalyst-au.net}
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use local_cleanurls\local\cleaner\cleaner;
+
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/../cleanurls_testcase.php');
+
+/**
+ * Tests.
+ *
+ * @package     local_cleanurls
+ * @author      Daniel Thee Roperto <daniel.roperto@catalyst-au.net>
+ * @copyright   2017 Catalyst IT Australia {@link http://www.catalyst-au.net}
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class local_cleanurls_cleaner_test extends local_cleanurls_testcase {
+    public function test_it_exists() {
+        self::assertTrue(class_exists('\local_cleanurls\local\cleaner\cleaner'));
+    }
+
+    public function test_it_keeps_trailing_slash() {
+        // It is important to keep the trailing slash to avoid a redirect from the webserver.
+
+        $unclean = new moodle_url('/login/index.php?foo=bar');
+        $clean = cleaner::clean($unclean);
+        self::assertSame('http://www.example.com/moodle/login/?foo=bar', $clean->raw_out());
+    }
+}

--- a/tests/phpunit/simple_test.php
+++ b/tests/phpunit/simple_test.php
@@ -167,7 +167,7 @@ class local_cleanurls_simple_test extends local_cleanurls_testcase {
         $url = 'http://www.example.com/moodle/course/index.php?foo=bar#hash';
         $murl = new moodle_url($url);
         $clean = $murl->out();
-        $this->assertEquals('http://www.example.com/moodle/course?foo=bar#hash', $clean, "Clean: Remove index");
+        $this->assertEquals('http://www.example.com/moodle/course/?foo=bar#hash', $clean, "Clean: Remove index");
 
         $url = 'http://www.example.com/moodle/admin/settings.php?section=local_cleanurls';
         $murl = new moodle_url($url);
@@ -193,7 +193,7 @@ class local_cleanurls_simple_test extends local_cleanurls_testcase {
         $url = 'http://www.example.com/moodle/course/index.php';
         $murl = new moodle_url($url);
         $clean = $murl->out();
-        $this->assertEquals('http://www.example.com/moodle/course', $clean, "Clean: index.php off url");
+        $this->assertEquals('http://www.example.com/moodle/course/', $clean, "Clean: index.php off url");
 
         // Nothing to unclean because these urls will get routed directly by apache not router.php.
 


### PR DESCRIPTION
Fixes #77 (cannot login) which was caused because without the trailing slash (login/) the webserver does a redirect instead of using the index.php file (destination).