### PR TITLE
Added check for null element to avoid TypeError: element is undefined…

### DIFF
--- a/classes/url_rewriter.php
+++ b/classes/url_rewriter.php
@@ -95,14 +95,16 @@ class url_rewriter implements \core\output\url_rewriter {
 <script>
 document.addEventListener('click', function (event) {
     var element = event.srcElement;
-    while (element.tagName != 'A') {
-        if (!element.parentElement) {
-            return;
+    if (element) {
+        while (element.tagName != 'A') {
+            if (!element.parentElement) {
+                return;
+            }
+            element = element.parentElement;
         }
-        element = element.parentElement;
-    }
-    if (element.getAttribute('href').charAt(0) == '#') {
-        element.href = '{$clean}' + element.getAttribute('href');
+        if (element.getAttribute('href').charAt(0) == '#') {
+            element.href = '{$clean}' + element.getAttribute('href');
+        }
     }
 }, true);
 </script>


### PR DESCRIPTION
Added check for null element to avoid "TypeError: element is undefined" error (in Firefox) as discussed in https://github.com/brendanheywood/moodle-local_cleanurls/issues/97